### PR TITLE
Contextual seeding works

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,46 @@
 
 ## Contributing
 
-Thank you for considering contributing to this application. Raise an issue, submit a PR. Be cool.
+Thank you for considering contributing to this application. Raise an issue, submit a PR. Be cool. It's likely we'll create a review preview instance for your contributions using Heroku Review apps.
+
+Please include separate PR-testing seeds as files with environment guards that check for the `DEPLOYMENT_TYPE` which will be the lowercase string "review" and have the `HEROKU_GIT_BRANCH` equal to your branch name.
+
+<details>
+<summary>Example of a contextual database seeder</summary>
+
+```php
+<?php
+
+class MyDatabaseSeeder extends ContextualDatabaseSeeder
+{
+  /**
+   * If this is null it will run on any branch.
+   * Otherwise branches matching (currently exact match only)
+   */
+  protected $_branch_name = null;
+  /**
+   * Can be one of:
+   * [
+   *   ANY, REVIEW_ONLY, PRODUCTION_ONLY, LOCAL_DEV_ONLY,
+   *   REVIEW_AND_LOCAL, REVIEW_AND_PRODUCTION, PRODUCTION_AND_LOCAL
+   * ]
+   */
+  protected $_guarded_environment = ContextualDatabaseSeeder::ANY;
+
+  /**
+     * Seed the application's database.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        if(!$this->guard()) { return; }
+        // Whatever seeding needs doing
+    }
+}
+```
+
+</details>
 
 ## Code of Conduct
 

--- a/app.json
+++ b/app.json
@@ -57,7 +57,8 @@
         "SESSION_DRIVER": "redis",
         "FILESYSTEM_DRIVER": "local",
         "DB_CONNECTION": "pgsql",
-        "DISABLE_REGISTRATION": true
+        "DISABLE_REGISTRATION": true,
+        "DEPLOYMENT_TYPE" : "review"
       }
     }
   },

--- a/database/seeds/ContextualDatabaseSeeder.php
+++ b/database/seeds/ContextualDatabaseSeeder.php
@@ -1,0 +1,134 @@
+<?php
+
+use Illuminate\Database\Seeder;
+
+abstract class ContextualDatabaseSeeder extends Seeder
+{
+    const ANY = '*';
+    const REVIEW_ONLY = 'REVIEW';
+    const PRODUCTION_ONLY = 'PRODUCTION';
+    const LOCAL_DEV_ONLY = 'LOCAL';
+    const REVIEW_AND_LOCAL = 'REVIEW+LOCAL';
+    const REVIEW_AND_PRODUCTION = 'REVIEW+PRODUCTION';
+    const PRODUCTION_AND_LOCAL = 'PRODUCTION+LOCAL';
+
+    protected $_branch_name = null;
+    protected $_guarded_environment = self::ANY;
+
+    /**
+     * Get Branch name
+     */
+    protected function deployed_branch() : ?string
+    {
+        return env("GIT_BRANCH", env("HEROKU_GIT_BRANCH"));
+    }
+
+    /**
+     * Get Deployment type
+     */
+    protected function deployment_type() : ?string
+    {
+        return env("DEPLOYMENT_TYPE");
+    }
+
+    /**
+    * Get Application Environment
+    */
+    protected function application_environment() : ?string
+    {
+        return env('APP_ENV');
+    }
+
+    /**
+     * Only return true if:
+     * 1. not a review app
+     * 2. production or local guarded environment
+     */
+    protected function production_or_local() : bool
+    {
+        return (
+            is_null($this->deployment_type()) &&
+            in_array(
+                $this->_guarded_environment,
+                [
+                    self::LOCAL_DEV_ONLY,
+                    self::PRODUCTION_ONLY,
+                    self::PRODUCTION_AND_LOCAL,
+                    self::REVIEW_AND_LOCAL,
+                    self::REVIEW_AND_PRODUCTION,
+                ],
+                true
+            )
+        );
+    }
+
+    /**
+     * Only return true if a review app in review-compatible guarded environment
+     */
+    protected function review_app_only() : bool
+    {
+        return (
+            $this->deployment_type() === "review" &&
+            in_array(
+                $this->_guarded_environment,
+                [
+                    self::REVIEW_ONLY,
+                    self::REVIEW_AND_LOCAL,
+                    self::REVIEW_AND_PRODUCTION,
+                ],
+                true
+            )
+        );
+    }
+
+    /**
+     * Only return true if in production and not guarded to local dev only
+     */
+    protected function needs_production() : bool
+    {
+        return (
+            $this->application_environment() === 'production' &&
+            !in_array($this->_guarded_environment, [self::LOCAL_DEV_ONLY, self::REVIEW_AND_LOCAL], true)
+        );
+    }
+
+    /**
+     * Only return true if not in production and not guarded to production only
+     */
+    protected function local_compatible() : bool
+    {
+        return (
+            $this->application_environment() !== 'production' &&
+            !in_array($this->_guarded_environment, [self::PRODUCTION_ONLY, self::REVIEW_AND_PRODUCTION], true)
+        );
+    }
+
+    /**
+     * Can Be Run in given environment
+     */
+    protected function can_run_in_env() : bool
+    {
+        return (
+            $this->_guarded_environment === self::ANY || 
+            $this->review_app_only() || (
+                $this->production_or_local() && (
+                    $this->needs_production() || 
+                    $this->local_compatible()
+                )
+            )
+        );
+    }
+
+    /**
+     * Predicate checking utility
+     * 
+     * This checks a set of rules to see if the seeder should run
+     */
+    public function guard() : bool
+    {
+        return (
+            ($this->_branch_name == $this->deployed_branch() || is_null($this->_branch_name)) &&
+            $this->can_run_in_env()
+        );
+    }
+}

--- a/tests/Unit/ContextualDatabaseSeederTest.php
+++ b/tests/Unit/ContextualDatabaseSeederTest.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+require __DIR__ . "/../../database/seeds/ContextualDatabaseSeeder.php";
+
+class ContextualTestSeeder extends \ContextualDatabaseSeeder {
+    const VALID_ENVIRONMENTS = [
+        \ContextualDatabaseSeeder::ANY,
+        \ContextualDatabaseSeeder::REVIEW_ONLY,
+        \ContextualDatabaseSeeder::PRODUCTION_ONLY,
+        \ContextualDatabaseSeeder::LOCAL_DEV_ONLY,
+        \ContextualDatabaseSeeder::REVIEW_AND_LOCAL,
+        \ContextualDatabaseSeeder::REVIEW_AND_PRODUCTION,
+        \ContextualDatabaseSeeder::PRODUCTION_AND_LOCAL,
+    ];
+
+    /**
+     * Specific implementation to aid testing without farting about with environment
+     */
+    public function __construct(?string $applicationEnv, ?string $deployType, ?string $deployedBranch, ?string $branchName, string $guardedEnvironment=\ContextualDatabaseSeeder::ANY)
+    {
+        $this->_branch_name = $branchName;
+        if (!in_array($guardedEnvironment, self::VALID_ENVIRONMENTS)) {
+            trigger_error("Invalid guarded environment", E_USER_ERROR);
+        }
+        $this->_guarded_environment = $guardedEnvironment;
+
+        $this->_deployed_branch = $deployedBranch;
+        $this->_deployment_type = $deployType;
+        $this->_application_environment = $applicationEnv;
+    }
+
+    protected function deployed_branch() : ?string { return $this->_deployed_branch; }
+    protected function deployment_type() : ?string { return $this->_deployment_type; }
+    protected function application_environment() : ?string { return $this->_application_environment; }
+}
+
+class ContextualDatabaseSeederTest extends TestCase
+{
+    /**
+     * Comprehensively test the guard clause
+     *
+     * @dataProvider guardClauseProvider
+     * 
+     * @return void
+     */
+    public function testGuardClause($args, $result)
+    {
+        $seeder = new ContextualTestSeeder(...$args);
+        $this->assertEquals($seeder->guard(), $result);
+    }
+
+    public function guardClauseProvider() {
+        return [
+            // In all these cases just use a regular seeder
+            'Local dev should pass empty guard?' => [['local', null, null, null], true],
+            'Production should pass empty guard?' => [['production', null, null, null], true],
+            'Review App should pass empty guard?' => [['production', 'review', null, null], true],
+            'Local dev App, no branch guard with branch, any ENV' => [['local', null, 'anything', null], true],
+            'Review App, no branch guard with branch, any ENV' => [['production', 'review', 'anything', null], true],
+            'Production App, no branch guard with branch, any ENV' => [['production', null, 'anything', null], true],
+
+            // Guarding when local deployed (ignore branch matching cases)
+            [['local', null, null, null, \ContextualDatabaseSeeder::REVIEW_AND_LOCAL], true],
+            [['local', null, null, null, \ContextualDatabaseSeeder::LOCAL_DEV_ONLY], true],
+            [['local', null, null, null, \ContextualDatabaseSeeder::PRODUCTION_AND_LOCAL], true],
+            [['local', null, null, null, \ContextualDatabaseSeeder::REVIEW_ONLY], false],
+            [['local', null, null, null, \ContextualDatabaseSeeder::PRODUCTION_ONLY], false],
+            [['local', null, null, null, \ContextualDatabaseSeeder::REVIEW_AND_PRODUCTION], false],
+
+            // Guarding when local deployed (branch matching cases)
+            [['local', null, null, null, \ContextualDatabaseSeeder::REVIEW_AND_LOCAL], true],
+            [['local', null, 'anything', null, \ContextualDatabaseSeeder::REVIEW_AND_LOCAL], true],
+            [['local', null, 'anything', 'anything', \ContextualDatabaseSeeder::REVIEW_AND_LOCAL], true],
+            [['local', null, null, 'wontmatch', \ContextualDatabaseSeeder::REVIEW_AND_LOCAL], false],
+            [['local', null, null, null, \ContextualDatabaseSeeder::LOCAL_DEV_ONLY], true],
+            [['local', null, 'anything', null, \ContextualDatabaseSeeder::LOCAL_DEV_ONLY], true],
+            [['local', null, 'anything', 'anything', \ContextualDatabaseSeeder::LOCAL_DEV_ONLY], true],
+            [['local', null, null, 'wontmatch', \ContextualDatabaseSeeder::LOCAL_DEV_ONLY], false],
+            [['local', null, null, null, \ContextualDatabaseSeeder::PRODUCTION_AND_LOCAL], true],
+            [['local', null, 'anything', null, \ContextualDatabaseSeeder::PRODUCTION_AND_LOCAL], true],
+            [['local', null, 'anything', 'anything', \ContextualDatabaseSeeder::PRODUCTION_AND_LOCAL], true],
+            [['local', null, null, 'wontmatch', \ContextualDatabaseSeeder::PRODUCTION_AND_LOCAL], false],
+
+            // Guarding when local deployed (branch matching cases)
+            [['local', null, null, null, \ContextualDatabaseSeeder::PRODUCTION_ONLY], false],
+            [['local', null, 'anything', null, \ContextualDatabaseSeeder::PRODUCTION_ONLY], false],
+            [['local', null, 'anything', 'anything', \ContextualDatabaseSeeder::PRODUCTION_ONLY], false],
+
+            // Guarding when local deployed with guard for non-local
+            [['local', null, null, null, \ContextualDatabaseSeeder::REVIEW_ONLY], false],
+            [['local', null, 'anything', null, \ContextualDatabaseSeeder::REVIEW_ONLY], false],
+            [['local', null, 'anything', 'anything', \ContextualDatabaseSeeder::REVIEW_ONLY], false],
+            [['local', null, null, null, \ContextualDatabaseSeeder::REVIEW_AND_PRODUCTION], false],
+            [['local', null, 'anything', null, \ContextualDatabaseSeeder::REVIEW_AND_PRODUCTION], false],
+            [['local', null, 'anything', 'anything', \ContextualDatabaseSeeder::REVIEW_AND_PRODUCTION], false],
+
+            // Guarding when production deployed (ignore branch matching cases)
+            [['production', null, null, null, \ContextualDatabaseSeeder::REVIEW_AND_LOCAL], false],
+            [['production', null, null, null, \ContextualDatabaseSeeder::LOCAL_DEV_ONLY], false],
+            [['production', null, null, null, \ContextualDatabaseSeeder::PRODUCTION_AND_LOCAL], true],
+            [['production', null, null, null, \ContextualDatabaseSeeder::REVIEW_ONLY], false],
+            [['production', null, null, null, \ContextualDatabaseSeeder::PRODUCTION_ONLY], true],
+            [['production', null, null, null, \ContextualDatabaseSeeder::REVIEW_AND_PRODUCTION], true],
+
+            // Guarding when production deployed (branch matching cases)
+            [['production', null, null, null, \ContextualDatabaseSeeder::REVIEW_AND_PRODUCTION], true],
+            [['production', null, 'anything', null, \ContextualDatabaseSeeder::REVIEW_AND_PRODUCTION], true],
+            [['production', null, 'anything', 'anything', \ContextualDatabaseSeeder::REVIEW_AND_PRODUCTION], true],
+            [['production', null, null, 'wontmatch', \ContextualDatabaseSeeder::REVIEW_AND_PRODUCTION], false],
+            [['production', null, null, null, \ContextualDatabaseSeeder::PRODUCTION_ONLY], true],
+            [['production', null, 'anything', null, \ContextualDatabaseSeeder::PRODUCTION_ONLY], true],
+            [['production', null, 'anything', 'anything', \ContextualDatabaseSeeder::PRODUCTION_ONLY], true],
+            [['production', null, null, 'wontmatch', \ContextualDatabaseSeeder::PRODUCTION_ONLY], false],
+            [['production', null, null, null, \ContextualDatabaseSeeder::PRODUCTION_AND_LOCAL], true],
+            [['production', null, 'anything', null, \ContextualDatabaseSeeder::PRODUCTION_AND_LOCAL], true],
+            [['production', null, 'anything', 'anything', \ContextualDatabaseSeeder::PRODUCTION_AND_LOCAL], true],
+            [['production', null, null, 'wontmatch', \ContextualDatabaseSeeder::PRODUCTION_AND_LOCAL], false],
+
+            // Guarding when review deployed (ignore branch matching cases)
+            [['production', 'review', null, null, \ContextualDatabaseSeeder::REVIEW_AND_LOCAL], true],
+            [['production', 'review', null, null, \ContextualDatabaseSeeder::LOCAL_DEV_ONLY], false],
+            [['production', 'review', null, null, \ContextualDatabaseSeeder::PRODUCTION_AND_LOCAL], false],
+            [['production', 'review', null, null, \ContextualDatabaseSeeder::REVIEW_ONLY], true],
+            [['production', 'review', null, null, \ContextualDatabaseSeeder::PRODUCTION_ONLY], false],
+            [['production', 'review', null, null, \ContextualDatabaseSeeder::REVIEW_AND_PRODUCTION], true],
+
+            // Guarding when production deployed (branch matching cases)
+            [['production', 'review', null, null, \ContextualDatabaseSeeder::REVIEW_AND_PRODUCTION], true],
+            [['production', 'review', 'anything', null, \ContextualDatabaseSeeder::REVIEW_AND_PRODUCTION], true],
+            [['production', 'review', 'anything', 'anything', \ContextualDatabaseSeeder::REVIEW_AND_PRODUCTION], true],
+            [['production', 'review', null, 'wontmatch', \ContextualDatabaseSeeder::REVIEW_AND_PRODUCTION], false],
+            [['production', 'review', null, null, \ContextualDatabaseSeeder::REVIEW_ONLY], true],
+            [['production', 'review', 'anything', null, \ContextualDatabaseSeeder::REVIEW_ONLY], true],
+            [['production', 'review', 'anything', 'anything', \ContextualDatabaseSeeder::REVIEW_ONLY], true],
+            [['production', 'review', null, 'wontmatch', \ContextualDatabaseSeeder::REVIEW_ONLY], false],
+            [['production', 'review', null, null, \ContextualDatabaseSeeder::REVIEW_AND_LOCAL], true],
+            [['production', 'review', 'anything', null, \ContextualDatabaseSeeder::REVIEW_AND_LOCAL], true],
+            [['production', 'review', 'anything', 'anything', \ContextualDatabaseSeeder::REVIEW_AND_LOCAL], true],
+            [['production', 'review', null, 'wontmatch', \ContextualDatabaseSeeder::REVIEW_AND_LOCAL], false],
+
+            'Review App, branch guard without branch, any ENV?' => [['production', 'review', null, 'wontmatch'], false],
+        ];
+    }
+}


### PR DESCRIPTION
I'd like PR's to include seed data.

Laravel by default only has a good mechanism for filtering on production.

If I were working on this for a long time, I might want PR branch-specific seed data, taking into account deployment-environment specific seed data.

While I could guard this per-seed, I think having central logic and a convention or language around this could help.

This PR is to add a specific type of special-case seeder for these seeds, which are designed to use the Environment to determine if a seed should run or simply return.