### PR TITLE
Verify if specifying node version breaks deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
         "sass-loader": "^8.0.0",
         "vue": "^2.5.17",
         "vue-template-compiler": "^2.6.10"
+    },
+    "engines": {
+        "node": "12.x"
     }
 }


### PR DESCRIPTION
https://dashboard.heroku.com/apps/larahack-apr-dependabot-hd9hle/activity/builds/75a02fb1-a78f-49a4-b8a2-20d612ff59a3 shows a deploy error when bumping lodash...

This looks at specifying a nodejs runtime. If it works still then I can merge it, and know documentation has improved even if it does not fix the bug, and if it does fix the bug then I'll have learned a new thing about needing to be explicit with system deps on heroku and Laravel.

Ruby on Rails has not had the same issue.